### PR TITLE
Organize project into function-specific modules

### DIFF
--- a/dinov2_unet/__init__.py
+++ b/dinov2_unet/__init__.py
@@ -1,0 +1,37 @@
+"""DINOv2-UNet 项目核心模块导出。"""
+
+from .config import TrainConfig
+from .data import KvasirSEG, create_dataset_splits
+from .evaluation import evaluate, dice_iou_from_logits, pixel_acc_from_logits
+from .inference import predict, save_predictions_to_dir
+from .models import DinoV2UNet
+from .training import (
+    ComboLoss,
+    DiceLoss,
+    build_scheduler,
+    make_optimizers,
+    train_one_epoch,
+)
+from .utils import count_params_m, denorm, estimate_gflops, save_visuals, set_seed
+
+__all__ = [
+    "TrainConfig",
+    "KvasirSEG",
+    "create_dataset_splits",
+    "DinoV2UNet",
+    "ComboLoss",
+    "DiceLoss",
+    "make_optimizers",
+    "build_scheduler",
+    "train_one_epoch",
+    "evaluate",
+    "dice_iou_from_logits",
+    "pixel_acc_from_logits",
+    "predict",
+    "save_predictions_to_dir",
+    "set_seed",
+    "denorm",
+    "count_params_m",
+    "estimate_gflops",
+    "save_visuals",
+]

--- a/dinov2_unet/config.py
+++ b/dinov2_unet/config.py
@@ -1,0 +1,22 @@
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+
+@dataclass
+class TrainConfig:
+    data_dir: str
+    img_size: int = 448
+    batch_size: int = 8
+    epochs: int = 80
+    backbone: str = "vit_base_patch14_dinov2"
+    out_indices: Tuple[int, ...] = (2, 5, 8, 11)
+    lr: float = 1e-3
+    lr_backbone: float = 1e-5
+    weight_decay: float = 0.01
+    warmup_epochs: int = 5
+    num_workers: int = 4
+    no_amp: bool = False
+    freeze_blocks_until: int = 9
+    save_dir: str = "./runs_dinov2_unet"
+    seed: int = 42
+    split_dir: Optional[str] = None

--- a/dinov2_unet/data/__init__.py
+++ b/dinov2_unet/data/__init__.py
@@ -1,0 +1,6 @@
+"""数据集加载与拆分工具。"""
+
+from .dataset import KvasirSEG
+from .split import create_dataset_splits
+
+__all__ = ["KvasirSEG", "create_dataset_splits"]

--- a/dinov2_unet/data/dataset.py
+++ b/dinov2_unet/data/dataset.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Iterable, List, Optional, Sequence, Tuple
+
+import numpy as np
+from PIL import Image
+from torch.utils.data import Dataset
+import torchvision.transforms.functional as TF
+
+
+def _list_image_files(img_dir: Path, extensions: Sequence[str]) -> List[str]:
+    names = [f for f in os.listdir(img_dir) if img_dir.joinpath(f).suffix.lower() in extensions]
+    names.sort()
+    return names
+
+
+def _load_split_file(split_file: Path) -> List[str]:
+    if not split_file.exists():
+        raise FileNotFoundError(f"Split file not found: {split_file}")
+    with split_file.open("r", encoding="utf-8") as f:
+        names = [line.strip() for line in f if line.strip()]
+    return names
+
+
+class KvasirSEG(Dataset):
+    """Kvasir-SEG 数据集加载与增强逻辑。"""
+
+    def __init__(
+        self,
+        data_dir: str,
+        split: str = "train",
+        img_size: int = 448,
+        mean: Tuple[float, float, float] = (0.485, 0.456, 0.406),
+        std: Tuple[float, float, float] = (0.229, 0.224, 0.225),
+        split_dir: Optional[str] = None,
+        extensions: Sequence[str] = (".jpg", ".jpeg", ".png", ".bmp"),
+    ) -> None:
+        super().__init__()
+        self.img_dir = Path(data_dir) / "images"
+        self.msk_dir = Path(data_dir) / "masks"
+        if split not in {"train", "val", "test"}:
+            raise ValueError("split must be 'train', 'val' or 'test'")
+
+        if split_dir is not None:
+            split_path = Path(split_dir)
+            names = _load_split_file(split_path / f"{split}.txt")
+        else:
+            names = _list_image_files(self.img_dir, extensions)
+            n = len(names)
+            n_train = int(n * 0.8)
+            n_val = int(n * 0.1)
+            if split == "train":
+                names = names[:n_train]
+            elif split == "val":
+                names = names[n_train : n_train + n_val]
+            else:
+                names = names[n_train + n_val :]
+
+        self.names = names
+        self.split = split
+        self.img_size = img_size
+        self.mean = mean
+        self.std = std
+
+    def __len__(self) -> int:
+        return len(self.names)
+
+    def _load_pair(self, name: str) -> Tuple[Image.Image, Image.Image]:
+        img_path = self.img_dir / name
+        stem = Path(name).stem
+        msk_path_png = self.msk_dir / f"{stem}.png"
+        msk_path_jpg = self.msk_dir / f"{stem}.jpg"
+        msk_path = msk_path_png if msk_path_png.exists() else msk_path_jpg
+        if not img_path.exists() or not msk_path.exists():
+            raise FileNotFoundError(f"Missing image or mask for {name}")
+        img = Image.open(img_path).convert("RGB")
+        msk = Image.open(msk_path).convert("L")
+        return img, msk
+
+    def _train_transform(self, img: Image.Image, msk: Image.Image):
+        img = img.resize((self.img_size, self.img_size), Image.BICUBIC)
+        msk = msk.resize((self.img_size, self.img_size), Image.NEAREST)
+        if np.random.rand() < 0.5:
+            img = TF.hflip(img)
+            msk = TF.hflip(msk)
+        angle = float(np.random.uniform(-10, 10))
+        img = TF.rotate(img, angle, interpolation=TF.InterpolationMode.BILINEAR)
+        msk = TF.rotate(msk, angle, interpolation=TF.InterpolationMode.NEAREST)
+        if np.random.rand() < 0.8:
+            img = TF.adjust_brightness(img, 0.9 + 0.2 * np.random.rand())
+            img = TF.adjust_contrast(img, 0.9 + 0.2 * np.random.rand())
+            img = TF.adjust_saturation(img, 0.9 + 0.2 * np.random.rand())
+        img = TF.to_tensor(img)
+        img = TF.normalize(img, mean=self.mean, std=self.std)
+        msk = TF.to_tensor(msk)
+        msk = (msk > 0.5).float()
+        return img, msk
+
+    def _val_transform(self, img: Image.Image, msk: Image.Image):
+        img = img.resize((self.img_size, self.img_size), Image.BICUBIC)
+        msk = msk.resize((self.img_size, self.img_size), Image.NEAREST)
+        img = TF.to_tensor(img)
+        img = TF.normalize(img, mean=self.mean, std=self.std)
+        msk = TF.to_tensor(msk)
+        msk = (msk > 0.5).float()
+        return img, msk
+
+    def __getitem__(self, idx: int):
+        name = self.names[idx]
+        img, msk = self._load_pair(name)
+        if self.split == "train":
+            img, msk = self._train_transform(img, msk)
+        else:
+            img, msk = self._val_transform(img, msk)
+        return img, msk, name

--- a/dinov2_unet/data/split.py
+++ b/dinov2_unet/data/split.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import random
+from pathlib import Path
+from typing import Sequence
+
+from .dataset import _list_image_files
+
+
+def create_dataset_splits(
+    data_dir: str,
+    output_dir: str,
+    train_ratio: float = 0.8,
+    val_ratio: float = 0.1,
+    seed: int = 42,
+    extensions: Sequence[str] = (".jpg", ".jpeg", ".png", ".bmp"),
+) -> None:
+    """将数据集拆分为 train/val/test 三个 txt 文件，记录图像文件名。"""
+
+    if train_ratio + val_ratio >= 1.0:
+        raise ValueError("train_ratio + val_ratio 必须小于 1.0")
+
+    rng = random.Random(seed)
+    img_dir = Path(data_dir) / "images"
+    names = _list_image_files(img_dir, extensions)
+    if not names:
+        raise RuntimeError(f"未在 {img_dir} 下找到图像文件")
+
+    rng.shuffle(names)
+    n = len(names)
+    n_train = int(n * train_ratio)
+    n_val = int(n * val_ratio)
+    train_names = names[:n_train]
+    val_names = names[n_train : n_train + n_val]
+    test_names = names[n_train + n_val :]
+
+    out_dir = Path(output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for split, split_names in zip(("train", "val", "test"), (train_names, val_names, test_names)):
+        with (out_dir / f"{split}.txt").open("w", encoding="utf-8") as f:
+            for name in split_names:
+                f.write(f"{name}\n")

--- a/dinov2_unet/evaluation/__init__.py
+++ b/dinov2_unet/evaluation/__init__.py
@@ -1,0 +1,6 @@
+"""模型评估指标与流程。"""
+
+from .evaluator import evaluate
+from .metrics import dice_iou_from_logits, pixel_acc_from_logits
+
+__all__ = ["evaluate", "dice_iou_from_logits", "pixel_acc_from_logits"]

--- a/dinov2_unet/evaluation/evaluator.py
+++ b/dinov2_unet/evaluation/evaluator.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import torch
+
+from ..training.losses import ComboLoss
+from .metrics import dice_iou_from_logits, pixel_acc_from_logits
+
+
+@torch.no_grad()
+def evaluate(model, loader, device: str, loss_fn: ComboLoss | None = None):
+    model.eval()
+    loss_fn = loss_fn or ComboLoss(0.5, 0.5)
+    total_loss, total_dice, total_iou, total_acc = 0.0, 0.0, 0.0, 0.0
+    iters = 0
+    for imgs, msks, _ in loader:
+        imgs, msks = imgs.to(device), msks.to(device)
+        logits = model(imgs)
+        loss = loss_fn(logits, msks)
+        d, i = dice_iou_from_logits(logits, msks)
+        a = pixel_acc_from_logits(logits, msks)
+        total_loss += loss.item()
+        total_dice += d
+        total_iou += i
+        total_acc += a
+        iters += 1
+    return total_loss / iters, total_dice / iters, total_iou / iters, total_acc / iters

--- a/dinov2_unet/evaluation/metrics.py
+++ b/dinov2_unet/evaluation/metrics.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import torch
+
+
+@torch.no_grad()
+def dice_iou_from_logits(logits: torch.Tensor, targets: torch.Tensor, thr: float = 0.5, eps: float = 1e-6):
+    probs = torch.sigmoid(logits)
+    preds = (probs > thr).float()
+    inter = (preds * targets).sum(dim=(2, 3))
+    union = (preds + targets - preds * targets).sum(dim=(2, 3))
+    dice = (2 * inter + eps) / (preds.sum(dim=(2, 3)) + targets.sum(dim=(2, 3)) + eps)
+    iou = (inter + eps) / (union + eps)
+    return dice.mean().item(), iou.mean().item()
+
+
+@torch.no_grad()
+def pixel_acc_from_logits(logits: torch.Tensor, targets: torch.Tensor, thr: float = 0.5):
+    """逐像素准确率：二值阈值后与GT一致的像素占比"""
+    probs = torch.sigmoid(logits)
+    preds = (probs > thr).float()
+    correct = (preds == targets).sum()
+    total = targets.numel()
+    return (correct.float() / total).item()

--- a/dinov2_unet/inference/__init__.py
+++ b/dinov2_unet/inference/__init__.py
@@ -1,0 +1,5 @@
+"""推理相关工具。"""
+
+from .predictor import predict, save_predictions_to_dir
+
+__all__ = ["predict", "save_predictions_to_dir"]

--- a/dinov2_unet/inference/predictor.py
+++ b/dinov2_unet/inference/predictor.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, Iterator, Tuple
+
+import torch
+from torchvision.utils import save_image
+
+from ..utils.visualization import denorm
+
+
+@torch.no_grad()
+def predict(model, loader, device: str, threshold: float = 0.5) -> Iterator[Tuple[Tuple[str, ...], torch.Tensor, torch.Tensor, torch.Tensor]]:
+    """逐批预测，返回 (文件名, 输入图像, 概率, 二值预测)。"""
+
+    model.eval()
+    for imgs, _, names in loader:
+        imgs = imgs.to(device)
+        logits = model(imgs)
+        probs = torch.sigmoid(logits)
+        preds = (probs > threshold).float()
+        yield tuple(names), imgs, probs, preds
+
+
+@torch.no_grad()
+def save_predictions_to_dir(
+    model,
+    loader,
+    device: str,
+    save_dir: str,
+    mean: Iterable[float],
+    std: Iterable[float],
+    threshold: float = 0.5,
+    max_batches: int | None = None,
+) -> None:
+    out_dir = Path(save_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for idx, (names, imgs, _, preds) in enumerate(predict(model, loader, device, threshold=threshold)):
+        imgs_denorm = denorm(imgs, mean, std)
+        for b, name in enumerate(names):
+            save_image(imgs_denorm[b], out_dir / f"{name}_img.png")
+            save_image(preds[b], out_dir / f"{name}_pred.png")
+        if max_batches is not None and idx + 1 >= max_batches:
+            break

--- a/dinov2_unet/models/__init__.py
+++ b/dinov2_unet/models/__init__.py
@@ -1,0 +1,5 @@
+"""模型结构定义。"""
+
+from .dinov2_unet import DinoV2UNet, FPNUNetDecoder, VitDinoV2Encoder
+
+__all__ = ["DinoV2UNet", "VitDinoV2Encoder", "FPNUNetDecoder"]

--- a/dinov2_unet/models/dinov2_unet.py
+++ b/dinov2_unet/models/dinov2_unet.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import math
+from typing import List, Tuple
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+try:
+    import timm
+except Exception as exc:  # pragma: no cover - informative message
+    raise RuntimeError("需要安装 timm: pip install timm") from exc
+
+
+class VitDinoV2Encoder(nn.Module):
+    """将 DINOv2 ViT 封装为语义分割编码器。"""
+
+    def __init__(
+        self,
+        backbone: str = "vit_base_patch14_dinov2",
+        out_indices: Tuple[int, ...] = (2, 5, 8, 11),
+        pretrained: bool = True,
+        freeze_blocks_until: int = 9,
+    ) -> None:
+        super().__init__()
+        self.model = timm.create_model(backbone, pretrained=pretrained, dynamic_img_size=True)
+        assert hasattr(self.model, "blocks"), "timm ViT 模型需要包含 blocks 属性"
+        if hasattr(self.model, "patch_embed") and hasattr(self.model.patch_embed, "dynamic_img_size"):
+            self.model.patch_embed.dynamic_img_size = True
+        self.out_indices = out_indices
+        self.patch_size = 14
+        if hasattr(self.model, "patch_embed") and hasattr(self.model.patch_embed, "patch_size"):
+            ps = self.model.patch_embed.patch_size
+            self.patch_size = ps[0] if isinstance(ps, tuple) else int(ps)
+        self.embed_dim = getattr(self.model, "embed_dim", None) or getattr(self.model, "num_features")
+        for i, blk in enumerate(self.model.blocks):
+            requires = i >= freeze_blocks_until
+            for p in blk.parameters():
+                p.requires_grad = requires
+        self.projs = nn.ModuleList([nn.Conv2d(self.embed_dim, 256, kernel_size=1) for _ in out_indices])
+
+    def forward(self, x: torch.Tensor) -> Tuple[List[torch.Tensor], Tuple[int, int], int]:
+        b, _, h, w = x.shape
+        x_pe = self.model.patch_embed(x)
+        if hasattr(self.model, "_pos_embed"):
+            pe_out = self.model._pos_embed(x_pe)
+            if isinstance(pe_out, (list, tuple)):
+                x_tokens, (gh, gw) = pe_out[0], pe_out[1]
+            else:
+                x_tokens = pe_out
+                gh, gw = h // self.patch_size, w // self.patch_size
+        else:
+            if x_pe.dim() == 4:
+                _, _, gh, gw = x_pe.shape
+                x_tokens = x_pe.flatten(2).transpose(1, 2)
+            else:
+                gh, gw = h // self.patch_size, w // self.patch_size
+                x_tokens = x_pe
+            cls_token = getattr(self.model, "cls_token", None)
+            if cls_token is not None:
+                cls_tokens = cls_token.expand(b, -1, -1)
+                x_tokens = torch.cat((cls_tokens, x_tokens), dim=1)
+            if hasattr(self.model, "pos_embed") and self.model.pos_embed is not None:
+                pos_embed = self.model.pos_embed
+                if pos_embed.shape[1] != x_tokens.shape[1]:
+                    has_cls = pos_embed.shape[1] == gh * gw + 1
+                    if has_cls:
+                        cls_pe, patch_pe = pos_embed[:, :1], pos_embed[:, 1:]
+                    else:
+                        cls_pe, patch_pe = None, pos_embed
+                    s = int(round(math.sqrt(patch_pe.shape[1])))
+                    patch_pe = patch_pe.transpose(1, 2).reshape(1, patch_pe.shape[2], s, s)
+                    patch_pe = F.interpolate(patch_pe, size=(gh, gw), mode="bicubic", align_corners=False)
+                    patch_pe = patch_pe.flatten(2).transpose(1, 2)
+                    pos_embed = torch.cat([cls_pe, patch_pe], dim=1) if cls_pe is not None else patch_pe
+                x_tokens = x_tokens + pos_embed
+
+        x_tokens = self.model.pos_drop(x_tokens)
+
+        feats_tokens = []
+        for i, blk in enumerate(self.model.blocks):
+            x_tokens = blk(x_tokens)
+            if i in self.out_indices:
+                feats_tokens.append(x_tokens)
+        x_tokens = self.model.norm(x_tokens)
+
+        feats = []
+        for tok, proj in zip(feats_tokens, self.projs):
+            if tok.shape[1] == (gh * gw + 1):
+                tok = tok[:, 1:, :]
+            fm = tok.transpose(1, 2).reshape(b, self.embed_dim, gh, gw)
+            fm = proj(fm)
+            feats.append(fm)
+        return feats, (gh, gw), self.patch_size
+
+
+class FPNUNetDecoder(nn.Module):
+    def __init__(self, num_in: int, out_ch: int = 1) -> None:
+        super().__init__()
+        self.lateral = nn.ModuleList([self._conv_bn_relu(256, 256) for _ in range(num_in)])
+        self.smooth = nn.ModuleList([self._conv_bn_relu(256, 256) for _ in range(num_in - 1)])
+        self.head = nn.Sequential(
+            self._conv_bn_relu(256, 128),
+            nn.Conv2d(128, out_ch, kernel_size=1),
+        )
+
+    @staticmethod
+    def _conv_bn_relu(cin: int, cout: int):
+        return nn.Sequential(
+            nn.Conv2d(cin, cout, kernel_size=3, padding=1, bias=False),
+            nn.BatchNorm2d(cout),
+            nn.ReLU(inplace=True),
+        )
+
+    def forward(
+        self,
+        feat_list: List[torch.Tensor],
+        grid_hw: Tuple[int, int],
+        patch_size: int,
+        out_size_hw: Tuple[int, int],
+    ):
+        del grid_hw, patch_size  # 未使用，但保留接口兼容性
+        lat = [l(f) for l, f in zip(self.lateral, feat_list)]
+        p = lat[-1]
+        for i in range(len(lat) - 2, -1, -1):
+            p = F.interpolate(p, size=lat[i].shape[-2:], mode="bilinear", align_corners=False) + lat[i]
+            p = self.smooth[i](p) if i < len(self.smooth) else p
+        logits = self.head(p)
+        logits = F.interpolate(logits, size=out_size_hw, mode="bilinear", align_corners=False)
+        return logits
+
+
+class DinoV2UNet(nn.Module):
+    def __init__(
+        self,
+        backbone: str = "vit_base_patch14_dinov2",
+        out_indices: Tuple[int, ...] = (2, 5, 8, 11),
+        pretrained: bool = True,
+        freeze_blocks_until: int = 9,
+        num_classes: int = 1,
+    ) -> None:
+        super().__init__()
+        self.encoder = VitDinoV2Encoder(backbone, out_indices, pretrained, freeze_blocks_until)
+        self.decoder = FPNUNetDecoder(num_in=len(out_indices), out_ch=num_classes)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        feats, (gh, gw), patch = self.encoder(x)
+        logits = self.decoder(feats, (gh, gw), patch, out_size_hw=(x.shape[2], x.shape[3]))
+        return logits

--- a/dinov2_unet/training/__init__.py
+++ b/dinov2_unet/training/__init__.py
@@ -1,0 +1,15 @@
+"""训练相关组件。"""
+
+from .loop import train_one_epoch
+from .losses import ComboLoss, DiceLoss
+from .optim import current_lrs, make_optimizers
+from .scheduler import build_scheduler
+
+__all__ = [
+    "train_one_epoch",
+    "ComboLoss",
+    "DiceLoss",
+    "make_optimizers",
+    "current_lrs",
+    "build_scheduler",
+]

--- a/dinov2_unet/training/loop.py
+++ b/dinov2_unet/training/loop.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import torch
+
+from ..evaluation.metrics import dice_iou_from_logits, pixel_acc_from_logits
+from .optim import current_lrs
+
+
+def train_one_epoch(model, loader, optim, scheduler, scaler, loss_fn, device: str, epoch: int):
+    model.train()
+    running_loss = 0.0
+    running_dice, running_iou, running_acc = 0.0, 0.0, 0.0
+    iters = 0
+    for it, (imgs, msks, _) in enumerate(loader):
+        imgs, msks = imgs.to(device, non_blocking=True), msks.to(device, non_blocking=True)
+        optim.zero_grad(set_to_none=True)
+        if scaler is not None:
+            autocast_device = "cuda" if device.startswith("cuda") else "cpu"
+            with torch.amp.autocast(autocast_device):
+                logits = model(imgs)
+                loss = loss_fn(logits, msks)
+            scaler.scale(loss).backward()
+            scaler.step(optim)
+            scaler.update()
+        else:
+            logits = model(imgs)
+            loss = loss_fn(logits, msks)
+            loss.backward()
+            optim.step()
+        scheduler.step()
+        with torch.no_grad():
+            d, i = dice_iou_from_logits(logits, msks)
+            a = pixel_acc_from_logits(logits, msks)
+        running_loss += loss.item()
+        running_dice += d
+        running_iou += i
+        running_acc += a
+        iters += 1
+        if it == 0 and epoch == 0:
+            print("LRs@start:", current_lrs(optim))
+    return running_loss / iters, running_dice / iters, running_iou / iters, running_acc / iters

--- a/dinov2_unet/training/losses.py
+++ b/dinov2_unet/training/losses.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+
+
+class DiceLoss(nn.Module):
+    def __init__(self, eps: float = 1e-6) -> None:
+        super().__init__()
+        self.eps = eps
+
+    def forward(self, logits: torch.Tensor, targets: torch.Tensor) -> torch.Tensor:
+        probs = torch.sigmoid(logits)
+        num = 2 * (probs * targets).sum(dim=(2, 3)) + self.eps
+        den = (probs.pow(2) + targets.pow(2)).sum(dim=(2, 3)) + self.eps
+        dice = (num / den).mean()
+        return 1 - dice
+
+
+class BCEWithLogitsLoss2D(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.loss = nn.BCEWithLogitsLoss()
+
+    def forward(self, logits: torch.Tensor, targets: torch.Tensor) -> torch.Tensor:
+        return self.loss(logits, targets)
+
+
+class ComboLoss(nn.Module):
+    def __init__(self, bce_weight: float = 0.5, dice_weight: float = 0.5) -> None:
+        super().__init__()
+        self.bce = BCEWithLogitsLoss2D()
+        self.dice = DiceLoss()
+        self.wb, self.wd = bce_weight, dice_weight
+
+    def forward(self, logits: torch.Tensor, targets: torch.Tensor) -> torch.Tensor:
+        return self.wb * self.bce(logits, targets) + self.wd * self.dice(logits, targets)

--- a/dinov2_unet/training/optim.py
+++ b/dinov2_unet/training/optim.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+from __future__ import annotations
+
+from typing import Dict
+
+import torch
+
+from ..config import TrainConfig
+from ..models import DinoV2UNet
+
+
+def make_optimizers(model: DinoV2UNet, cfg: TrainConfig):
+    enc_params, dec_params = [], []
+    for name, param in model.named_parameters():
+        if not param.requires_grad:
+            continue
+        if name.startswith("encoder"):
+            enc_params.append(param)
+        else:
+            dec_params.append(param)
+    optim = torch.optim.AdamW(
+        [
+            {"params": enc_params, "lr": cfg.lr_backbone, "name": "enc"},
+            {"params": dec_params, "lr": cfg.lr, "name": "dec"},
+        ],
+        weight_decay=cfg.weight_decay,
+    )
+    return optim
+
+
+def current_lrs(optimizer) -> Dict[str, float]:
+    return {group.get("name", str(i)): group["lr"] for i, group in enumerate(optimizer.param_groups)}

--- a/dinov2_unet/training/scheduler.py
+++ b/dinov2_unet/training/scheduler.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import math
+
+import torch
+
+
+def build_scheduler(optimizer, epochs: int, steps_per_epoch: int, warmup_epochs: int = 0):
+    total_iters = max(1, epochs * steps_per_epoch)
+    warmup_iters = max(0, warmup_epochs * steps_per_epoch)
+
+    def lr_lambda(current_iter: int):
+        if warmup_iters > 0 and current_iter < warmup_iters:
+            return float(current_iter) / float(max(1, warmup_iters))
+        progress = (current_iter - warmup_iters) / float(max(1, total_iters - warmup_iters))
+        return 0.01 + 0.99 * 0.5 * (1.0 + math.cos(math.pi * progress))
+
+    return torch.optim.lr_scheduler.LambdaLR(optimizer, lr_lambda=lambda it: lr_lambda(it))

--- a/dinov2_unet/utils/__init__.py
+++ b/dinov2_unet/utils/__init__.py
@@ -1,0 +1,12 @@
+"""通用辅助函数。"""
+
+from .misc import count_params_m, estimate_gflops, set_seed
+from .visualization import denorm, save_visuals
+
+__all__ = [
+    "set_seed",
+    "denorm",
+    "count_params_m",
+    "estimate_gflops",
+    "save_visuals",
+]

--- a/dinov2_unet/utils/misc.py
+++ b/dinov2_unet/utils/misc.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import random
+
+import numpy as np
+import torch
+
+
+def set_seed(seed: int = 42):
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+
+
+def count_params_m(model: torch.nn.Module) -> float:
+    """参数量（百万级）"""
+    return sum(p.numel() for p in model.parameters()) / 1e6
+
+
+@torch.no_grad()
+def estimate_gflops(model: torch.nn.Module, img_size: int, device: str = "cuda") -> float | None:
+    """用 thop 估算FLOPs（MACs×2），失败则返回None"""
+    try:
+        from thop import profile
+
+        model_ = model.eval()
+        dummy = torch.randn(1, 3, img_size, img_size, device=device)
+        macs, _ = profile(model_, inputs=(dummy,), verbose=False)
+        flops = macs * 2
+        return flops / 1e9
+    except Exception:
+        return None

--- a/dinov2_unet/utils/visualization.py
+++ b/dinov2_unet/utils/visualization.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Iterable, Tuple
+
+import torch
+from torchvision.utils import save_image
+
+
+def denorm(x: torch.Tensor, mean: Iterable[float], std: Iterable[float]):
+    mean_t = torch.tensor(mean, device=x.device).view(1, -1, 1, 1)
+    std_t = torch.tensor(std, device=x.device).view(1, -1, 1, 1)
+    return x * std_t + mean_t
+
+
+@torch.no_grad()
+def save_visuals(
+    model,
+    loader,
+    device: str,
+    save_dir: str,
+    mean: Tuple[float, ...],
+    std: Tuple[float, ...],
+    max_batches: int = 2,
+    threshold: float = 0.5,
+):
+    Path(save_dir).mkdir(parents=True, exist_ok=True)
+    model.eval()
+    cnt = 0
+    for imgs, _, names in loader:
+        imgs = imgs.to(device)
+        logits = model(imgs)
+        probs = torch.sigmoid(logits)
+        preds = (probs > threshold).float()
+        imgs_denorm = denorm(imgs, mean, std)
+        for b in range(imgs.size(0)):
+            save_image(imgs_denorm[b], os.path.join(save_dir, f"{names[b]}_img.png"))
+            save_image(preds[b], os.path.join(save_dir, f"{names[b]}_pred.png"))
+        cnt += 1
+        if cnt >= max_batches:
+            break

--- a/evaluate.py
+++ b/evaluate.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python
+# coding: utf-8
+"""模型评估脚本。"""
+
+import argparse
+
+import torch
+from torch.utils.data import DataLoader
+
+from dinov2_unet import DinoV2UNet, KvasirSEG, TrainConfig, evaluate, set_seed
+
+
+def _parse_out_indices(value: str):
+    parts = [p.strip() for p in value.split(",") if p.strip()]
+    if not parts:
+        raise argparse.ArgumentTypeError("out_indices 不能为空")
+    return tuple(int(p) for p in parts)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="评估训练好的 DINOv2-UNet 模型")
+    parser.add_argument("--data_dir", type=str, required=True)
+    parser.add_argument("--checkpoint", type=str, required=True)
+    parser.add_argument("--split", type=str, default="test", choices=["train", "val", "test"])
+    parser.add_argument("--img_size", type=int, default=448)
+    parser.add_argument("--batch_size", type=int, default=8)
+    parser.add_argument("--backbone", type=str, default="vit_base_patch14_dinov2")
+    parser.add_argument("--out_indices", type=_parse_out_indices, default=(2, 5, 8, 11))
+    parser.add_argument("--freeze_blocks_until", type=int, default=9)
+    parser.add_argument("--num_workers", type=int, default=4)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--split_dir", type=str, default=None, help="train/val/test txt 文件所在目录")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    set_seed(args.seed)
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+
+    cfg = TrainConfig(
+        data_dir=args.data_dir,
+        img_size=args.img_size,
+        batch_size=args.batch_size,
+        backbone=args.backbone,
+        out_indices=args.out_indices,
+        freeze_blocks_until=args.freeze_blocks_until,
+        num_workers=args.num_workers,
+        seed=args.seed,
+        split_dir=args.split_dir,
+    )
+
+    mean = (0.485, 0.456, 0.406)
+    std = (0.229, 0.224, 0.225)
+
+    dataset = KvasirSEG(cfg.data_dir, args.split, cfg.img_size, mean, std, split_dir=cfg.split_dir)
+    loader = DataLoader(
+        dataset,
+        batch_size=cfg.batch_size,
+        shuffle=False,
+        num_workers=cfg.num_workers,
+        pin_memory=True,
+    )
+
+    model = DinoV2UNet(
+        backbone=cfg.backbone,
+        out_indices=cfg.out_indices,
+        pretrained=False,
+        freeze_blocks_until=cfg.freeze_blocks_until,
+        num_classes=1,
+    ).to(device)
+    ckpt = torch.load(args.checkpoint, map_location="cpu")
+    state = ckpt.get("model", ckpt)
+    model.load_state_dict(state)
+
+    metrics = evaluate(model, loader, device)
+    te_loss, te_dice, te_iou, te_acc = metrics
+    print(
+        f"{args.split} split | loss {te_loss:.4f} dice {te_dice:.4f} "
+        f"iou {te_iou:.4f} acc {te_acc:.4f}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/predict.py
+++ b/predict.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+# coding: utf-8
+"""模型推理脚本。"""
+
+import argparse
+
+import torch
+from torch.utils.data import DataLoader
+
+from dinov2_unet import DinoV2UNet, KvasirSEG, TrainConfig, save_predictions_to_dir, set_seed
+
+
+def _parse_out_indices(value: str):
+    parts = [p.strip() for p in value.split(",") if p.strip()]
+    if not parts:
+        raise argparse.ArgumentTypeError("out_indices 不能为空")
+    return tuple(int(p) for p in parts)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="使用训练好的 DINOv2-UNet 进行推理")
+    parser.add_argument("--data_dir", type=str, required=True)
+    parser.add_argument("--checkpoint", type=str, required=True)
+    parser.add_argument("--output", type=str, required=True, help="保存预测掩码的目录")
+    parser.add_argument("--split", type=str, default="test", choices=["train", "val", "test"])
+    parser.add_argument("--img_size", type=int, default=448)
+    parser.add_argument("--batch_size", type=int, default=8)
+    parser.add_argument("--backbone", type=str, default="vit_base_patch14_dinov2")
+    parser.add_argument("--out_indices", type=_parse_out_indices, default=(2, 5, 8, 11))
+    parser.add_argument("--freeze_blocks_until", type=int, default=9)
+    parser.add_argument("--num_workers", type=int, default=4)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--split_dir", type=str, default=None)
+    parser.add_argument("--max_batches", type=int, default=None, help="可选，只保存前若干个批次")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    set_seed(args.seed)
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+
+    cfg = TrainConfig(
+        data_dir=args.data_dir,
+        img_size=args.img_size,
+        batch_size=args.batch_size,
+        backbone=args.backbone,
+        out_indices=args.out_indices,
+        freeze_blocks_until=args.freeze_blocks_until,
+        num_workers=args.num_workers,
+        seed=args.seed,
+        split_dir=args.split_dir,
+    )
+
+    mean = (0.485, 0.456, 0.406)
+    std = (0.229, 0.224, 0.225)
+
+    dataset = KvasirSEG(cfg.data_dir, args.split, cfg.img_size, mean, std, split_dir=cfg.split_dir)
+    loader = DataLoader(
+        dataset,
+        batch_size=cfg.batch_size,
+        shuffle=False,
+        num_workers=cfg.num_workers,
+        pin_memory=True,
+    )
+
+    model = DinoV2UNet(
+        backbone=cfg.backbone,
+        out_indices=cfg.out_indices,
+        pretrained=False,
+        freeze_blocks_until=cfg.freeze_blocks_until,
+        num_classes=1,
+    ).to(device)
+    ckpt = torch.load(args.checkpoint, map_location="cpu")
+    state = ckpt.get("model", ckpt)
+    model.load_state_dict(state)
+
+    save_predictions_to_dir(
+        model,
+        loader,
+        device,
+        args.output,
+        mean,
+        std,
+        max_batches=args.max_batches,
+    )
+    print(f"预测结果已保存至 {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/split_dataset.py
+++ b/split_dataset.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+# coding: utf-8
+"""Kvasir-SEG 数据集划分脚本。"""
+
+import argparse
+
+from dinov2_unet import create_dataset_splits
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="按比例划分 Kvasir-SEG 数据集")
+    parser.add_argument("data_dir", type=str, help="包含 images/masks 的数据集根目录")
+    parser.add_argument("output", type=str, help="保存 train/val/test txt 的目录")
+    parser.add_argument("--train_ratio", type=float, default=0.8)
+    parser.add_argument("--val_ratio", type=float, default=0.1)
+    parser.add_argument("--seed", type=int, default=42)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    create_dataset_splits(
+        data_dir=args.data_dir,
+        output_dir=args.output,
+        train_ratio=args.train_ratio,
+        val_ratio=args.val_ratio,
+        seed=args.seed,
+    )
+    print(f"已在 {args.output} 生成 train/val/test 列表。")
+
+
+if __name__ == "__main__":
+    main()

--- a/train.py
+++ b/train.py
@@ -1,523 +1,131 @@
 #!/usr/bin/env python
 # coding: utf-8
-"""
-DINOv2-UNet for Kvasir-SEG (Polyp Segmentation)
-------------------------------------------------
-- timm 加载 DINOv2 ViT 作为编码器
-- FPN/UNet 风格解码器（跨层融合 + 逐步上采样）
-- 训练、验证、Dice/IoU/PixelAcc 指标，可视化，最优权重保存
-- 学习率：全组共享 warmup+cosine 调度因子（保留 enc/dec 不同基准 LR）
-- 训练前统计 Params(M) 与 FLOPs(G)（需 thop；未安装则优雅降级）
+"""DINOv2-UNet training entry point."""
 
-用法示例（PowerShell）:
-python train.py --data_dir D:\DINOv2\kvasir-seg --img_size 448 --batch_size 8 --epochs 80 --backbone vit_base_patch14_dinov2 --lr 1e-3 --lr_backbone 1e-5
-"""
+import os
+import time
+import argparse
+
+import torch
+from torch.utils.data import DataLoader
+
+from dinov2_unet import (
+    ComboLoss,
+    DinoV2UNet,
+    KvasirSEG,
+    TrainConfig,
+    build_scheduler,
+    count_params_m,
+    estimate_gflops,
+    evaluate,
+    make_optimizers,
+    save_predictions_to_dir,
+    set_seed,
+    train_one_epoch,
+)
+
 
 # ====== 环境变量：抑制无关警告 ======
-import os
 os.environ["KMP_DUPLICATE_LIB_OK"] = "TRUE"
 os.environ["HF_HUB_DISABLE_SYMLINKS_WARNING"] = "1"
 os.environ["ALBUMENTATIONS_DISABLE_VERSION_CHECK"] = "1"
 
-import math
-import time
-import argparse
-from dataclasses import dataclass
-from typing import List, Tuple
 
-import numpy as np
-from PIL import Image
-
-import torch
-import torch.nn as nn
-import torch.nn.functional as F
-from torch.utils.data import Dataset, DataLoader
-import torchvision.transforms.functional as TF
-from torchvision.utils import save_image
-
-try:
-    import timm
-except Exception as e:
-    raise RuntimeError("需要安装 timm: pip install timm")
-
-# =============================
-# Utils
-# =============================
-def set_seed(seed: int = 42):
-    import random
-    random.seed(seed)
-    np.random.seed(seed)
-    torch.manual_seed(seed)
-    torch.cuda.manual_seed_all(seed)
-
-def denorm(x: torch.Tensor, mean, std):
-    mean = torch.tensor(mean, device=x.device).view(1, -1, 1, 1)
-    std = torch.tensor(std, device=x.device).view(1, -1, 1, 1)
-    return x * std + mean
-
-# =============================
-# Dataset
-# =============================
-class KvasirSEG(Dataset):
-    """Kvasir-SEG 数据集
-    data_dir/
-      ├─ images/  *.jpg|*.png
-      └─ masks/   *.png (0/255 或 0/1)
-    """
-    def __init__(self, data_dir: str, split: str = 'train', img_size: int = 448,
-                 mean=(0.485,0.456,0.406), std=(0.229,0.224,0.225)):
-        super().__init__()
-        self.img_dir = os.path.join(data_dir, 'images')
-        self.msk_dir = os.path.join(data_dir, 'masks')
-        exts = {'.jpg', '.jpeg', '.png', '.bmp'}
-        names = [f for f in os.listdir(self.img_dir) if os.path.splitext(f)[1].lower() in exts]
-        names.sort()
-        # 简单划分：8/1/1
-        n = len(names)
-        n_train = int(n * 0.8)
-        n_val = int(n * 0.1)
-        if split == 'train':
-            self.names = names[:n_train]
-        elif split == 'val':
-            self.names = names[n_train:n_train+n_val]
-        else:
-            self.names = names[n_train+n_val:]
-        self.split = split
-        self.img_size = img_size
-        self.mean = mean
-        self.std = std
-
-    def __len__(self):
-        return len(self.names)
-
-    def _load_pair(self, name):
-        img_path = os.path.join(self.img_dir, name)
-        stem = os.path.splitext(name)[0]
-        msk_path_png = os.path.join(self.msk_dir, stem + '.png')
-        msk_path = msk_path_png if os.path.exists(msk_path_png) else os.path.join(self.msk_dir, stem + '.jpg')
-        img = Image.open(img_path).convert('RGB')
-        msk = Image.open(msk_path).convert('L')
-        return img, msk
-
-    def _train_transform(self, img: Image.Image, msk: Image.Image):
-        img = img.resize((self.img_size, self.img_size), Image.BICUBIC)
-        msk = msk.resize((self.img_size, self.img_size), Image.NEAREST)
-        if np.random.rand() < 0.5:
-            img = TF.hflip(img)
-            msk = TF.hflip(msk)
-        angle = float(np.random.uniform(-10, 10))
-        img = TF.rotate(img, angle, interpolation=TF.InterpolationMode.BILINEAR)
-        msk = TF.rotate(msk, angle, interpolation=TF.InterpolationMode.NEAREST)
-        if np.random.rand() < 0.8:
-            img = TF.adjust_brightness(img, 0.9 + 0.2*np.random.rand())
-            img = TF.adjust_contrast(img, 0.9 + 0.2*np.random.rand())
-            img = TF.adjust_saturation(img, 0.9 + 0.2*np.random.rand())
-        img = TF.to_tensor(img)
-        img = TF.normalize(img, mean=self.mean, std=self.std)
-        msk = TF.to_tensor(msk)
-        msk = (msk > 0.5).float()
-        return img, msk
-
-    def _val_transform(self, img: Image.Image, msk: Image.Image):
-        img = img.resize((self.img_size, self.img_size), Image.BICUBIC)
-        msk = msk.resize((self.img_size, self.img_size), Image.NEAREST)
-        img = TF.to_tensor(img)
-        img = TF.normalize(img, mean=self.mean, std=self.std)
-        msk = TF.to_tensor(msk)
-        msk = (msk > 0.5).float()
-        return img, msk
-
-    def __getitem__(self, idx):
-        name = self.names[idx]
-        img, msk = self._load_pair(name)
-        if self.split == 'train':
-            img, msk = self._train_transform(img, msk)
-        else:
-            img, msk = self._val_transform(img, msk)
-        return img, msk, name
-
-# =============================
-# Losses & Metrics
-# =============================
-class DiceLoss(nn.Module):
-    def __init__(self, eps=1e-6):
-        super().__init__()
-        self.eps = eps
-    def forward(self, logits, targets):
-        probs = torch.sigmoid(logits)
-        num = 2 * (probs * targets).sum(dim=(2,3)) + self.eps
-        den = (probs.pow(2) + targets.pow(2)).sum(dim=(2,3)) + self.eps
-        dice = (num / den).mean()
-        return 1 - dice
-
-class BCEWithLogitsLoss2D(nn.Module):
-    def __init__(self):
-        super().__init__()
-        self.loss = nn.BCEWithLogitsLoss()
-    def forward(self, logits, targets):
-        return self.loss(logits, targets)
-
-class ComboLoss(nn.Module):
-    def __init__(self, bce_weight=0.5, dice_weight=0.5):
-        super().__init__()
-        self.bce = BCEWithLogitsLoss2D()
-        self.dice = DiceLoss()
-        self.wb, self.wd = bce_weight, dice_weight
-    def forward(self, logits, targets):
-        return self.wb*self.bce(logits, targets) + self.wd*self.dice(logits, targets)
-
-@torch.no_grad()
-def dice_iou_from_logits(logits, targets, thr=0.5, eps=1e-6):
-    probs = torch.sigmoid(logits)
-    preds = (probs > thr).float()
-    inter = (preds * targets).sum(dim=(2,3))
-    union = (preds + targets - preds*targets).sum(dim=(2,3))
-    dice = (2*inter + eps) / (preds.sum(dim=(2,3)) + targets.sum(dim=(2,3)) + eps)
-    iou = (inter + eps) / (union + eps)
-    return dice.mean().item(), iou.mean().item()
-
-@torch.no_grad()
-def pixel_acc_from_logits(logits, targets, thr=0.5):
-    """逐像素准确率：二值阈值后与GT一致的像素占比"""
-    probs = torch.sigmoid(logits)
-    preds = (probs > thr).float()
-    correct = (preds == targets).sum()
-    total = targets.numel()
-    return (correct.float() / total).item()
-
-def count_params_m(model: nn.Module) -> float:
-    """参数量（百万级）"""
-    return sum(p.numel() for p in model.parameters()) / 1e6
-
-@torch.no_grad()
-def estimate_gflops(model: nn.Module, img_size: int, device: str = "cuda") -> float | None:
-    """用 thop 估算FLOPs（MACs×2），失败则返回None"""
-    try:
-        from thop import profile
-        model_ = model.eval()
-        dummy = torch.randn(1, 3, img_size, img_size, device=device)
-        macs, _ = profile(model_, inputs=(dummy,), verbose=False)
-        flops = macs * 2  # 约定：FLOPs ≈ 2*MACs
-        return flops / 1e9  # 转为 GFLOPs
-    except Exception:
-        return None
-
-# =============================
-# DINOv2 ViT Encoder (timm)
-# =============================
-class VitDinoV2Encoder(nn.Module):
-    """将 DINOv2 ViT 封装为语义分割编码器。"""
-    def __init__(self, backbone='vit_base_patch14_dinov2', out_indices=(2,5,8,11),
-                 pretrained=True, freeze_blocks_until=9):
-        super().__init__()
-        self.model = timm.create_model(backbone, pretrained=pretrained, dynamic_img_size=True)
-        assert hasattr(self.model, 'blocks'), 'timm ViT 模型需要包含 blocks 属性'
-        if hasattr(self.model, 'patch_embed') and hasattr(self.model.patch_embed, 'dynamic_img_size'):
-            self.model.patch_embed.dynamic_img_size = True
-        self.out_indices = out_indices
-        # patch size & embed dim
-        self.patch_size = 14
-        if hasattr(self.model, 'patch_embed') and hasattr(self.model.patch_embed, 'patch_size'):
-            ps = self.model.patch_embed.patch_size
-            self.patch_size = ps[0] if isinstance(ps, tuple) else int(ps)
-        self.embed_dim = getattr(self.model, 'embed_dim', None) or getattr(self.model, 'num_features')
-        # 冻结前半部分 blocks（小数据集上更稳）
-        for i, blk in enumerate(self.model.blocks):
-            requires = (i >= freeze_blocks_until)
-            for p in blk.parameters():
-                p.requires_grad = requires
-        # 选取层的 1x1 卷积投影到 256 通道
-        self.projs = nn.ModuleList([nn.Conv2d(self.embed_dim, 256, kernel_size=1) for _ in out_indices])
-
-    def forward(self, x: torch.Tensor) -> Tuple[List[torch.Tensor], Tuple[int, int], int]:
-        B, C, H, W = x.shape
-
-        # 使用 timm 的内部 _pos_embed 来统一处理 patch_embed / cls / 位置编码（自动插值）
-        x_pe = self.model.patch_embed(x)
-        if hasattr(self.model, '_pos_embed'):
-            pe_out = self.model._pos_embed(x_pe)
-            if isinstance(pe_out, (list, tuple)):
-                x_tokens, (Gh, Gw) = pe_out[0], pe_out[1]  # (B, 1+N, C), (Gh, Gw)
-            else:
-                x_tokens = pe_out
-                Gh, Gw = H // self.patch_size, W // self.patch_size
-        else:
-            # 极少模型没有 _pos_embed：回退到手动适配 3D/4D + 插值 pos_embed
-            if x_pe.dim() == 4:
-                B_, C_, Gh, Gw = x_pe.shape
-                x_tokens = x_pe.flatten(2).transpose(1, 2)  # (B, N, C_)
-            else:
-                Gh, Gw = H // self.patch_size, W // self.patch_size
-                x_tokens = x_pe  # (B, N, C)
-            cls_token = getattr(self.model, 'cls_token', None)
-            if cls_token is not None:
-                cls_tokens = cls_token.expand(B, -1, -1)
-                x_tokens = torch.cat((cls_tokens, x_tokens), dim=1)
-            if hasattr(self.model, 'pos_embed') and self.model.pos_embed is not None:
-                pos_embed = self.model.pos_embed
-                if pos_embed.shape[1] != x_tokens.shape[1]:
-                    has_cls = (pos_embed.shape[1] == Gh*Gw + 1)
-                    if has_cls:
-                        cls_pe, patch_pe = pos_embed[:, :1], pos_embed[:, 1:]
-                    else:
-                        cls_pe, patch_pe = None, pos_embed
-                    s = int(round(math.sqrt(patch_pe.shape[1])))
-                    patch_pe = patch_pe.transpose(1,2).reshape(1, patch_pe.shape[2], s, s)
-                    patch_pe = F.interpolate(patch_pe, size=(Gh, Gw), mode='bicubic', align_corners=False)
-                    patch_pe = patch_pe.flatten(2).transpose(1,2)
-                    pos_embed = torch.cat([cls_pe, patch_pe], dim=1) if cls_pe is not None else patch_pe
-                x_tokens = x_tokens + pos_embed
-
-        x_tokens = self.model.pos_drop(x_tokens)
-
-        feats_tokens = []
-        for i, blk in enumerate(self.model.blocks):
-            x_tokens = blk(x_tokens)
-            if i in self.out_indices:
-                feats_tokens.append(x_tokens)
-        x_tokens = self.model.norm(x_tokens)
-
-        feats = []
-        for tok, proj in zip(feats_tokens, self.projs):
-            if tok.shape[1] == (Gh * Gw + 1):
-                tok = tok[:, 1:, :]
-            fm = tok.transpose(1, 2).reshape(B, self.embed_dim, Gh, Gw)
-            fm = proj(fm)
-            feats.append(fm)
-        return feats, (Gh, Gw), self.patch_size
-
-# =============================
-# UNet/FPN 风格 Decoder
-# =============================
-class FPNUNetDecoder(nn.Module):
-    def __init__(self, num_in: int, out_ch: int = 1):
-        super().__init__()
-        self.lateral = nn.ModuleList([self._conv_bn_relu(256, 256) for _ in range(num_in)])
-        self.smooth = nn.ModuleList([self._conv_bn_relu(256, 256) for _ in range(num_in-1)])
-        self.head = nn.Sequential(
-            self._conv_bn_relu(256, 128),
-            nn.Conv2d(128, out_ch, kernel_size=1)
-        )
-
-    @staticmethod
-    def _conv_bn_relu(cin, cout):
-        return nn.Sequential(
-            nn.Conv2d(cin, cout, kernel_size=3, padding=1, bias=False),
-            nn.BatchNorm2d(cout),
-            nn.ReLU(inplace=True),
-        )
-
-    def forward(self, feat_list: List[torch.Tensor], grid_hw: Tuple[int,int], patch_size: int, out_size_hw: Tuple[int,int]):
-        lat = [l(f) for l, f in zip(self.lateral, feat_list)]
-        p = lat[-1]
-        for i in range(len(lat)-2, -1, -1):
-            p = F.interpolate(p, size=lat[i].shape[-2:], mode='bilinear', align_corners=False) + lat[i]
-            p = self.smooth[i](p) if i < len(self.smooth) else p
-        logits = self.head(p)
-        logits = F.interpolate(logits, size=out_size_hw, mode='bilinear', align_corners=False)
-        return logits
-
-# =============================
-# 全模型封装
-# =============================
-class DinoV2UNet(nn.Module):
-    def __init__(self, backbone='vit_base_patch14_dinov2', out_indices=(2,5,8,11),
-                 pretrained=True, freeze_blocks_until=9, num_classes=1):
-        super().__init__()
-        self.encoder = VitDinoV2Encoder(backbone, out_indices, pretrained, freeze_blocks_until)
-        self.decoder = FPNUNetDecoder(num_in=len(out_indices), out_ch=num_classes)
-
-    def forward(self, x):
-        feats, (Gh, Gw), p = self.encoder(x)
-        logits = self.decoder(feats, (Gh, Gw), p, out_size_hw=(x.shape[2], x.shape[3]))
-        return logits
-
-# =============================
-# 训练工具
-# =============================
-@dataclass
-class TrainConfig:
-    data_dir: str
-    img_size: int = 448
-    batch_size: int = 8
-    epochs: int = 80
-    backbone: str = 'vit_base_patch14_dinov2'
-    out_indices: Tuple[int,...] = (2,5,8,11)
-    lr: float = 1e-3
-    lr_backbone: float = 1e-5
-    weight_decay: float = 0.01
-    warmup_epochs: int = 5
-    num_workers: int = 4
-    no_amp: bool = False
-    freeze_blocks_until: int = 9
-    save_dir: str = './runs_dinov2_unet'
-    seed: int = 42
-
-def make_optimizers(model: DinoV2UNet, cfg: TrainConfig):
-    enc_params, dec_params = [], []
-    for n, p in model.named_parameters():
-        if not p.requires_grad:
-            continue
-        if n.startswith('encoder'):
-            enc_params.append(p)
-        else:
-            dec_params.append(p)
-    optim = torch.optim.AdamW([
-        {'params': enc_params, 'lr': cfg.lr_backbone, 'name': 'enc'},
-        {'params': dec_params, 'lr': cfg.lr,          'name': 'dec'},
-    ], weight_decay=cfg.weight_decay)
-    return optim
-
-def build_scheduler(optimizer, epochs, steps_per_epoch, warmup_epochs=0):
-    total_iters = max(1, epochs * steps_per_epoch)
-    warmup_iters = max(0, warmup_epochs * steps_per_epoch)
-
-    def lr_lambda(current_iter):
-        if warmup_iters > 0 and current_iter < warmup_iters:
-            return float(current_iter) / float(max(1, warmup_iters))
-        progress = (current_iter - warmup_iters) / float(max(1, total_iters - warmup_iters))
-        return 0.01 + 0.99 * 0.5 * (1.0 + math.cos(math.pi * progress))
-
-    return torch.optim.lr_scheduler.LambdaLR(optimizer, lr_lambda=lambda it: lr_lambda(it))
-
-def _current_lrs(optim):
-    return { (g.get('name', str(i))): g['lr'] for i, g in enumerate(optim.param_groups) }
-
-def train_one_epoch(model, loader, optim, scheduler, scaler, loss_fn, device, epoch):
-    model.train()
-    running_loss = 0.0
-    running_dice, running_iou, running_acc = 0.0, 0.0, 0.0
-    iters = 0
-    for it, (imgs, msks, _) in enumerate(loader):
-        imgs, msks = imgs.to(device, non_blocking=True), msks.to(device, non_blocking=True)
-        optim.zero_grad(set_to_none=True)
-        if not scaler is None:
-            with torch.amp.autocast('cuda' if device.startswith('cuda') else 'cpu'):
-                logits = model(imgs)
-                loss = loss_fn(logits, msks)
-            scaler.scale(loss).backward()
-            scaler.step(optim)
-            scaler.update()
-        else:
-            logits = model(imgs)
-            loss = loss_fn(logits, msks)
-            loss.backward()
-            optim.step()
-        scheduler.step()  # 每步调度
-        with torch.no_grad():
-            d, i = dice_iou_from_logits(logits, msks)
-            a = pixel_acc_from_logits(logits, msks)
-        running_loss += loss.item()
-        running_dice += d
-        running_iou += i
-        running_acc += a
-        iters += 1
-        if it == 0 and epoch == 0:
-            print("LRs@start:", _current_lrs(optim))
-    return running_loss/iters, running_dice/iters, running_iou/iters, running_acc/iters
-
-@torch.no_grad()
-def evaluate(model, loader, device):
-    model.eval()
-    loss_fn = ComboLoss(0.5, 0.5)
-    total_loss, total_dice, total_iou, total_acc = 0.0, 0.0, 0.0, 0.0
-    iters = 0
-    for imgs, msks, _ in loader:
-        imgs, msks = imgs.to(device), msks.to(device)
-        logits = model(imgs)
-        loss = loss_fn(logits, msks)
-        d, i = dice_iou_from_logits(logits, msks)
-        a = pixel_acc_from_logits(logits, msks)
-        total_loss += loss.item(); total_dice += d; total_iou += i; total_acc += a
-        iters += 1
-    return total_loss/iters, total_dice/iters, total_iou/iters, total_acc/iters
-
-@torch.no_grad()
-def save_visuals(model, loader, device, save_dir, mean, std, max_batches=2):
-    os.makedirs(save_dir, exist_ok=True)
-    model.eval()
-    cnt = 0
-    for imgs, msks, names in loader:
-        imgs = imgs.to(device)
-        logits = model(imgs)
-        probs = torch.sigmoid(logits)
-        preds = (probs > 0.5).float()
-        imgs_denorm = denorm(imgs, mean, std)
-        for b in range(imgs.size(0)):
-            save_image(imgs_denorm[b], os.path.join(save_dir, f"{names[b]}_img.png"))
-            save_image(preds[b], os.path.join(save_dir, f"{names[b]}_pred.png"))
-        cnt += 1
-        if cnt >= max_batches:
-            break
-
-# =============================
-# Main
-# =============================
-def main():
+def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
-    parser.add_argument('--data_dir', type=str, required=True)
-    parser.add_argument('--img_size', type=int, default=448)
-    parser.add_argument('--batch_size', type=int, default=8)
-    parser.add_argument('--epochs', type=int, default=80)
-    parser.add_argument('--backbone', type=str, default='vit_base_patch14_dinov2')
-    parser.add_argument('--freeze_blocks_until', type=int, default=9)
-    parser.add_argument('--lr', type=float, default=1e-3)
-    parser.add_argument('--lr_backbone', type=float, default=1e-5)
-    parser.add_argument('--weight_decay', type=float, default=0.01)
-    parser.add_argument('--warmup_epochs', type=int, default=5)
-    parser.add_argument('--num_workers', type=int, default=4)
-    parser.add_argument('--no_amp', action='store_true')
-    parser.add_argument('--save_dir', type=str, default='./runs_dinov2_unet')
-    parser.add_argument('--seed', type=int, default=42)
-    args = parser.parse_args()
+    parser.add_argument("--data_dir", type=str, required=True)
+    parser.add_argument("--img_size", type=int, default=448)
+    parser.add_argument("--batch_size", type=int, default=8)
+    parser.add_argument("--epochs", type=int, default=80)
+    parser.add_argument("--backbone", type=str, default="vit_base_patch14_dinov2")
+    parser.add_argument("--freeze_blocks_until", type=int, default=9)
+    parser.add_argument("--lr", type=float, default=1e-3)
+    parser.add_argument("--lr_backbone", type=float, default=1e-5)
+    parser.add_argument("--weight_decay", type=float, default=0.01)
+    parser.add_argument("--warmup_epochs", type=int, default=5)
+    parser.add_argument("--num_workers", type=int, default=4)
+    parser.add_argument("--no_amp", action="store_true")
+    parser.add_argument("--save_dir", type=str, default="./runs_dinov2_unet")
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--split_dir", type=str, default=None, help="可选的 train/val/test 列表目录")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
 
     set_seed(args.seed)
-    device = 'cuda' if torch.cuda.is_available() else 'cpu'
+    device = "cuda" if torch.cuda.is_available() else "cpu"
     os.makedirs(args.save_dir, exist_ok=True)
 
     mean = (0.485, 0.456, 0.406)
     std = (0.229, 0.224, 0.225)
 
-    # Datasets
-    train_ds = KvasirSEG(args.data_dir, 'train', args.img_size, mean, std)
-    val_ds   = KvasirSEG(args.data_dir, 'val', args.img_size, mean, std)
-    test_ds  = KvasirSEG(args.data_dir, 'test', args.img_size, mean, std)
+    train_ds = KvasirSEG(args.data_dir, "train", args.img_size, mean, std, split_dir=args.split_dir)
+    val_ds = KvasirSEG(args.data_dir, "val", args.img_size, mean, std, split_dir=args.split_dir)
+    test_ds = KvasirSEG(args.data_dir, "test", args.img_size, mean, std, split_dir=args.split_dir)
 
-    train_loader = DataLoader(train_ds, batch_size=args.batch_size, shuffle=True,
-                              num_workers=args.num_workers, pin_memory=True, drop_last=True)
-    val_loader = DataLoader(val_ds, batch_size=args.batch_size, shuffle=False,
-                            num_workers=args.num_workers, pin_memory=True)
-    test_loader = DataLoader(test_ds, batch_size=args.batch_size, shuffle=False,
-                             num_workers=args.num_workers, pin_memory=True)
+    train_loader = DataLoader(
+        train_ds,
+        batch_size=args.batch_size,
+        shuffle=True,
+        num_workers=args.num_workers,
+        pin_memory=True,
+        drop_last=True,
+    )
+    val_loader = DataLoader(
+        val_ds,
+        batch_size=args.batch_size,
+        shuffle=False,
+        num_workers=args.num_workers,
+        pin_memory=True,
+    )
+    test_loader = DataLoader(
+        test_ds,
+        batch_size=args.batch_size,
+        shuffle=False,
+        num_workers=args.num_workers,
+        pin_memory=True,
+    )
 
-    # Model + Optim + Sched
-    cfg = TrainConfig(**{k: v for k, v in vars(args).items() if k in TrainConfig.__dataclass_fields__})
-    model = DinoV2UNet(backbone=cfg.backbone,
-                       out_indices=(2,5,8,11),
-                       pretrained=True,
-                       freeze_blocks_until=cfg.freeze_blocks_until,
-                       num_classes=1).to(device)
+    cfg = TrainConfig(
+        **{k: v for k, v in vars(args).items() if k in TrainConfig.__dataclass_fields__}
+    )
+    model = DinoV2UNet(
+        backbone=cfg.backbone,
+        out_indices=cfg.out_indices,
+        pretrained=True,
+        freeze_blocks_until=cfg.freeze_blocks_until,
+        num_classes=1,
+    ).to(device)
 
     optim = make_optimizers(model, cfg)
-    # AMP：新式 API
-    scaler = torch.amp.GradScaler('cuda', enabled=(not cfg.no_amp))
+    scaler = torch.amp.GradScaler("cuda", enabled=(not cfg.no_amp))
     iters_per_epoch = len(train_loader)
-    scheduler = build_scheduler(optim, epochs=cfg.epochs, steps_per_epoch=iters_per_epoch, warmup_epochs=cfg.warmup_epochs)
+    scheduler = build_scheduler(
+        optim,
+        epochs=cfg.epochs,
+        steps_per_epoch=iters_per_epoch,
+        warmup_epochs=cfg.warmup_epochs,
+    )
 
-    # 复杂度（一次性）
     params_m = count_params_m(model)
     gflops = estimate_gflops(model, cfg.img_size, device=device)
     if gflops is None:
-        print(f"[Info] GFLOPs 估算未启用（未安装 thop 或计算失败）。")
+        print("[Info] GFLOPs 估算未启用（未安装 thop 或计算失败）。")
     else:
-        print(f"[Info] 模型复杂度：Params={params_m:.2f}M, FLOPs≈{gflops:.2f}G @ {cfg.img_size}x{cfg.img_size}")
+        print(
+            f"[Info] 模型复杂度：Params={params_m:.2f}M, FLOPs≈{gflops:.2f}G @ {cfg.img_size}x{cfg.img_size}"
+        )
 
     loss_fn = ComboLoss(0.5, 0.5)
     best_val = -1.0
 
     for epoch in range(cfg.epochs):
         t0 = time.time()
-        tr_loss, tr_dice, tr_iou, tr_acc = train_one_epoch(model, train_loader, optim, scheduler, scaler, loss_fn, device, epoch)
+        tr_loss, tr_dice, tr_iou, tr_acc = train_one_epoch(
+            model, train_loader, optim, scheduler, scaler, loss_fn, device, epoch
+        )
         va_loss, va_dice, va_iou, va_acc = evaluate(model, val_loader, device)
         dt = time.time() - t0
 
@@ -526,27 +134,47 @@ def main():
             extra += f" flops {gflops:.2f}G"
 
         print(
-            f"Epoch {epoch+1:03d}/{cfg.epochs} | time {dt:.1f}s | "
+            f"Epoch {epoch + 1:03d}/{cfg.epochs} | time {dt:.1f}s | "
             f"train: loss {tr_loss:.4f} dice {tr_dice:.4f} iou {tr_iou:.4f} acc {tr_acc:.4f} | "
             f"val: loss {va_loss:.4f} dice {va_dice:.4f} iou {va_iou:.4f} acc {va_acc:.4f}"
             f"{extra}"
         )
 
-        # 保存 best（基于 (Dice+IoU)/2）
         score = (va_dice + va_iou) / 2
         if score > best_val:
             best_val = score
-            torch.save({'model': model.state_dict(), 'epoch': epoch+1}, os.path.join(cfg.save_dir, 'best.pt'))
+            torch.save(
+                {"model": model.state_dict(), "epoch": epoch + 1},
+                os.path.join(cfg.save_dir, "best.pt"),
+            )
 
-        if (epoch+1) % 10 == 0:
-            save_visuals(model, val_loader, device, os.path.join(cfg.save_dir, f'vis_ep{epoch+1:03d}'), mean, std)
+        if (epoch + 1) % 10 == 0:
+            save_predictions_to_dir(
+                model,
+                val_loader,
+                device,
+                os.path.join(cfg.save_dir, f"vis_ep{epoch + 1:03d}"),
+                mean,
+                std,
+                max_batches=2,
+            )
 
-    # Test（载入 best）
-    ckpt = torch.load(os.path.join(cfg.save_dir, 'best.pt'), map_location='cpu')
-    model.load_state_dict(ckpt['model'])
+    ckpt = torch.load(os.path.join(cfg.save_dir, "best.pt"), map_location="cpu")
+    model.load_state_dict(ckpt["model"])
     te_loss, te_dice, te_iou, te_acc = evaluate(model, test_loader, device)
-    print(f"Test | loss {te_loss:.4f} dice {te_dice:.4f} iou {te_iou:.4f} acc {te_acc:.4f}")
-    save_visuals(model, test_loader, device, os.path.join(cfg.save_dir, 'vis_test'), mean, std, max_batches=4)
+    print(
+        f"Test | loss {te_loss:.4f} dice {te_dice:.4f} iou {te_iou:.4f} acc {te_acc:.4f}"
+    )
+    save_predictions_to_dir(
+        model,
+        test_loader,
+        device,
+        os.path.join(cfg.save_dir, "vis_test"),
+        mean,
+        std,
+        max_batches=4,
+    )
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- reorganize the `dinov2_unet` package into feature-focused subpackages for data handling, model architecture, training loops, evaluation, inference, and shared utilities
- add dataset splitting helpers plus optional split file support in `TrainConfig`/`KvasirSEG`, and update `train.py` to leverage the new modular layout and inference-based visual exports
- provide dedicated CLI scripts for dataset partitioning, offline evaluation, and prediction generation

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d34f800b108324aab427347fab30b1